### PR TITLE
Split random by newlines

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -221,6 +221,8 @@ Would anybody want it?
 You are an engineer
 You can only make one dot at a time
 You don't have to be ashamed of using your own ideas</string>
+				<key>wordseparatortype</key>
+				<integer>1</integer>
 			</dict>
 			<key>type</key>
 			<string>alfred.workflow.utility.random</string>


### PR DESCRIPTION
Because some of the sentences have commas, sometimes the random can produce a sentence fragment. This pull request fixes it with a new addition to the Random Utility.

<img width="490" alt="image" src="https://user-images.githubusercontent.com/1699443/232148350-8dfc3a2c-1c3b-4c96-bc98-a1a07d0749bc.png">

Because the addition is in Alfred 5.1, the new version should only be released when it’s out of pre-release and into the stable channel.

If it’s easier to just close the pull request and do the change yourself, that’s fine. No pressure to merge.